### PR TITLE
feat: add user and refresh token models

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,6 @@
-# empty
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+__all__ = ["db"]

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,25 @@
 import os
+from typing import Any, Mapping
+
 from flask import Flask, jsonify
 from flask_cors import CORS
 
-def create_app() -> Flask:
+from src import db
+
+
+def create_app(config: Mapping[str, Any] | None = None) -> Flask:
     app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URI", "sqlite:///umbra-auth.db")
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    if config:
+        app.config.update(config)
+
     CORS(app)
+    db.init_app(app)
+
+    # Ensure models are registered with SQLAlchemy metadata
+    from src import models  # noqa: F401
 
     @app.get("/health")
     def health():
@@ -15,6 +30,7 @@ def create_app() -> Flask:
         }), 200
 
     return app
+
 
 if __name__ == "__main__":
     app = create_app()

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Mapped
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from src import db
+
+
+class User(db.Model):
+    __tablename__ = "users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False)
+    password_hash = db.Column(db.String(255), nullable=False)
+    created_at = db.Column(
+        db.DateTime(timezone=True), server_default=db.func.now(), nullable=False
+    )
+
+    refresh_tokens: Mapped[list["RefreshToken"]] = db.relationship(
+        "RefreshToken",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    def set_password(self, password: str) -> None:
+        """Hash and store the user's password."""
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        """Verify that the provided password matches the stored hash."""
+        if not self.password_hash:
+            return False
+        return check_password_hash(self.password_hash, password)
+
+
+class RefreshToken(db.Model):
+    __tablename__ = "refresh_tokens"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    token = db.Column(db.String(255), unique=True, nullable=False)
+    revoked = db.Column(db.Boolean, default=False, nullable=False)
+    expires_at = db.Column(db.DateTime(timezone=True), nullable=False)
+    created_at = db.Column(
+        db.DateTime(timezone=True), server_default=db.func.now(), nullable=False
+    )
+
+    user: Mapped[User] = db.relationship("User", back_populates="refresh_tokens", lazy="joined")
+
+    def is_expired(self, reference_time: datetime | None = None) -> bool:
+        """Return True if the refresh token is expired at the given time."""
+        reference_time = reference_time or datetime.now(timezone.utc)
+
+        expires_at = self.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+
+        if reference_time.tzinfo is None:
+            reference_time = reference_time.replace(tzinfo=timezone.utc)
+
+        return expires_at <= reference_time

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from src import db
+from src.main import create_app
+
+
+@pytest.fixture()
+def app():
+    app = create_app({
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "TESTING": True,
+    })
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta, timezone
+
+from src import db
+from src.models import RefreshToken, User
+
+
+def test_user_password_hashing(app):
+    with app.app_context():
+        user = User(email="test@example.com")
+        user.set_password("password123")
+        db.session.add(user)
+        db.session.commit()
+
+        assert user.password_hash != "password123"
+        assert user.check_password("password123")
+        assert not user.check_password("wrong-password")
+
+
+def test_refresh_token_relationship(app):
+    with app.app_context():
+        user = User(email="owner@example.com")
+        user.set_password("strong-password")
+        db.session.add(user)
+        db.session.commit()
+
+        refresh_token = RefreshToken(
+            user=user,
+            token="refresh-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        db.session.add(refresh_token)
+        db.session.commit()
+
+        assert refresh_token.user == user
+        assert refresh_token in user.refresh_tokens
+        assert not refresh_token.revoked
+        assert not refresh_token.is_expired(datetime.now(timezone.utc))


### PR DESCRIPTION
## Summary
- configure Flask app with SQLAlchemy extension
- add User and RefreshToken ORM models with password helpers and expiration check
- cover the new models with fixtures and unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d194122a7c8332a307345d29f21d3a