### PR TITLE
feat: implement user registration endpoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,10 @@
 import os
+from datetime import timedelta
 from typing import Any, Mapping
 
 from flask import Flask, jsonify
 from flask_cors import CORS
+from flask_jwt_extended import JWTManager
 
 from src import db
 
@@ -11,15 +13,22 @@ def create_app(config: Mapping[str, Any] | None = None) -> Flask:
     app = Flask(__name__)
     app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URI", "sqlite:///umbra-auth.db")
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config.setdefault("JWT_SECRET_KEY", os.getenv("JWT_SECRET_KEY", "change-me"))
+    app.config.setdefault("JWT_ACCESS_TOKEN_EXPIRES", timedelta(minutes=15))
+    app.config.setdefault("JWT_REFRESH_TOKEN_EXPIRES", timedelta(days=7))
 
     if config:
         app.config.update(config)
 
     CORS(app)
     db.init_app(app)
+    JWTManager(app)
 
     # Ensure models are registered with SQLAlchemy metadata
     from src import models  # noqa: F401
+    from src.routes.auth import auth_bp
+
+    app.register_blueprint(auth_bp)
 
     @app.get("/health")
     def health():

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -1,0 +1,5 @@
+"""Application routes package."""
+
+from .auth import auth_bp
+
+__all__ = ["auth_bp"]

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+
+from flask import Blueprint, current_app, jsonify, request
+from flask_jwt_extended import create_access_token, create_refresh_token
+from sqlalchemy.exc import IntegrityError
+
+from src import db
+from src.models import RefreshToken, User
+
+EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+auth_bp = Blueprint("auth", __name__)
+
+
+def _normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+def _validate_input(data: dict[str, object]) -> tuple[dict[str, str], str | None, str | None]:
+    email = data.get("email")
+    password = data.get("password")
+
+    errors: dict[str, str] = {}
+    normalized_email: str | None = None
+    normalized_password: str | None = None
+
+    if not isinstance(email, str) or not email.strip():
+        errors["email"] = "Email requis."
+    else:
+        normalized_email = _normalize_email(email)
+        if not EMAIL_REGEX.fullmatch(normalized_email):
+            errors["email"] = "Email invalide."
+
+    if not isinstance(password, str) or not password:
+        errors["password"] = "Mot de passe requis."
+    elif len(password) < 8:
+        errors["password"] = "Le mot de passe doit contenir au moins 8 caractères."
+    else:
+        normalized_password = password
+
+    return errors, normalized_email, normalized_password
+
+
+def _resolve_refresh_token_expiry(now: datetime) -> datetime:
+    expires = current_app.config.get("JWT_REFRESH_TOKEN_EXPIRES")
+
+    if isinstance(expires, timedelta):
+        expires_delta = expires
+    elif isinstance(expires, int):
+        expires_delta = timedelta(seconds=expires)
+    elif expires in {None, True}:
+        expires_delta = timedelta(days=30)
+    elif expires is False:
+        expires_delta = timedelta(days=3650)
+    else:
+        raise TypeError("Invalid JWT_REFRESH_TOKEN_EXPIRES configuration")
+
+    return now + expires_delta
+
+
+@auth_bp.post("/auth/register")
+def register():
+    payload = request.get_json(silent=True) or {}
+    errors, email, password = _validate_input(payload)
+
+    if errors:
+        return (
+            jsonify({"success": False, "errors": errors, "message": "Données invalides."}),
+            400,
+        )
+
+    assert email is not None and password is not None  # For type checkers
+
+    existing_user = db.session.execute(db.select(User).filter_by(email=email)).scalar_one_or_none()
+    if existing_user is not None:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "errors": {"email": "Un utilisateur avec cet email existe déjà."},
+                    "message": "Conflit de données.",
+                }
+            ),
+            409,
+        )
+
+    user = User(email=email)
+    user.set_password(password)
+
+    db.session.add(user)
+
+    try:
+        db.session.flush()
+    except IntegrityError:
+        db.session.rollback()
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "errors": {"email": "Un utilisateur avec cet email existe déjà."},
+                    "message": "Conflit de données.",
+                }
+            ),
+            409,
+        )
+
+    access_token = create_access_token(identity=user.id)
+    refresh_token = create_refresh_token(identity=user.id)
+
+    now = datetime.now(timezone.utc)
+    refresh_token_entry = RefreshToken(
+        user=user,
+        token=refresh_token,
+        expires_at=_resolve_refresh_token_expiry(now),
+    )
+    db.session.add(refresh_token_entry)
+
+    db.session.commit()
+
+    return (
+        jsonify(
+            {
+                "success": True,
+                "data": {
+                    "user": {"id": user.id, "email": user.email},
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                },
+                "message": "Utilisateur créé avec succès.",
+            }
+        ),
+        201,
+    )

--- a/tests/test_auth_register.py
+++ b/tests/test_auth_register.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from src import db
+from src.models import RefreshToken, User
+
+
+def test_register_success(app):
+    client = app.test_client()
+
+    response = client.post(
+        "/auth/register",
+        json={"email": "NewUser@example.com", "password": "StrongPass123"},
+    )
+
+    assert response.status_code == HTTPStatus.CREATED
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"]["user"]["email"] == "newuser@example.com"
+    assert payload["data"]["user"]["id"] is not None
+    assert payload["data"]["access_token"]
+    assert payload["data"]["refresh_token"]
+
+    with app.app_context():
+        user = db.session.execute(
+            db.select(User).filter_by(email="newuser@example.com")
+        ).scalar_one()
+        assert user.check_password("StrongPass123")
+        assert len(user.refresh_tokens) == 1
+        stored_token = user.refresh_tokens[0]
+        assert stored_token.token == payload["data"]["refresh_token"]
+        assert not stored_token.revoked
+
+
+def test_register_duplicate_email(app):
+    client = app.test_client()
+
+    first_response = client.post(
+        "/auth/register",
+        json={"email": "duplicate@example.com", "password": "StrongPass123"},
+    )
+    assert first_response.status_code == HTTPStatus.CREATED
+
+    response = client.post(
+        "/auth/register",
+        json={"email": "duplicate@example.com", "password": "AnotherPass123"},
+    )
+    assert response.status_code == HTTPStatus.CONFLICT
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert "email" in payload["errors"]
+
+    with app.app_context():
+        users = db.session.execute(db.select(User)).scalars().all()
+        assert len(users) == 1
+        assert users[0].check_password("StrongPass123")
+
+
+def test_register_invalid_email(app):
+    client = app.test_client()
+
+    response = client.post(
+        "/auth/register", json={"email": "invalid-email", "password": "StrongPass123"}
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert "email" in payload["errors"]
+
+
+def test_register_invalid_password(app):
+    client = app.test_client()
+
+    response = client.post(
+        "/auth/register", json={"email": "valid@example.com", "password": "short"}
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert "password" in payload["errors"]
+
+    with app.app_context():
+        assert db.session.execute(db.select(User)).scalar_one_or_none() is None
+        assert db.session.execute(db.select(RefreshToken)).scalar_one_or_none() is None


### PR DESCRIPTION
## Summary
- add an auth blueprint exposing POST /auth/register with validation and token issuance
- configure JWT defaults in the app factory and persist refresh tokens in the database
- cover registration success and error cases with dedicated tests

## Testing
- pytest -v --cov=src

------
https://chatgpt.com/codex/tasks/task_e_68d1a5c52b948332a1c4f1bb29341525