### PR TITLE
Add profile/logout endpoints and rotate refresh tokens

### DIFF
--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -1,0 +1,13 @@
+# Issues Overview
+
+This repository previously tracked several authentication-related issues. The
+following table summarises their current status based on the implemented
+features in this update.
+
+| Issue | Description | Status |
+| --- | --- | --- |
+| #12 | Rotate refresh tokens whenever they are exchanged to avoid token reuse. | ✅ Closed |
+| #13 | Provide an endpoint allowing a client to revoke a refresh token (logout). | ✅ Closed |
+| #14 | Expose an authenticated endpoint to retrieve the current user's profile. | ✅ Closed |
+
+No additional open issues remain after these changes.

--- a/tests/test_auth_logout.py
+++ b/tests/test_auth_logout.py
@@ -1,0 +1,60 @@
+from http import HTTPStatus
+
+from src import db
+from src.models import RefreshToken
+
+
+def _register_user(client):
+    response = client.post(
+        "/auth/register",
+        json={"email": "logout@example.com", "password": "StrongPass123"},
+    )
+    return response.get_json()
+
+
+def test_logout_revokes_refresh_token(app):
+    client = app.test_client()
+    registration_payload = _register_user(client)
+    refresh_token = registration_payload["data"]["refresh_token"]
+
+    response = client.post(
+        "/auth/logout", json={"refresh_token": refresh_token}
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"]["revoked"] is True
+    assert payload["message"] == "Déconnexion effectuée."
+
+    with app.app_context():
+        token_entry = db.session.execute(
+            db.select(RefreshToken).filter_by(token=refresh_token)
+        ).scalar_one()
+        assert token_entry.revoked is True
+
+
+def test_logout_requires_refresh_token(app):
+    client = app.test_client()
+
+    response = client.post("/auth/logout", json={})
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["errors"]["refresh_token"] == "Refresh token requis."
+    assert payload["message"] == "Données invalides."
+
+
+def test_logout_is_idempotent_for_unknown_token(app):
+    client = app.test_client()
+
+    response = client.post(
+        "/auth/logout", json={"refresh_token": "unknown-token"}
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"]["revoked"] is True
+    assert payload["message"] == "Déconnexion effectuée."

--- a/tests/test_auth_me.py
+++ b/tests/test_auth_me.py
@@ -1,0 +1,60 @@
+from http import HTTPStatus
+
+from src import db
+from src.models import User
+
+
+def _register_user(client):
+    response = client.post(
+        "/auth/register",
+        json={"email": "me@example.com", "password": "StrongPass123"},
+    )
+    return response.get_json()
+
+
+def test_me_returns_current_user_profile(app):
+    client = app.test_client()
+    registration_payload = _register_user(client)
+    access_token = registration_payload["data"]["access_token"]
+
+    response = client.get(
+        "/auth/me", headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["data"]["user"]["email"] == "me@example.com"
+    assert payload["message"] == "Profil utilisateur récupéré."
+
+
+def test_me_returns_not_found_when_user_missing(app):
+    client = app.test_client()
+    registration_payload = _register_user(client)
+    access_token = registration_payload["data"]["access_token"]
+    user_id = registration_payload["data"]["user"]["id"]
+
+    with app.app_context():
+        user = db.session.get(User, user_id)
+        db.session.delete(user)
+        db.session.commit()
+
+    response = client.get(
+        "/auth/me", headers={"Authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    payload = response.get_json()
+    assert payload["success"] is False
+    assert payload["errors"]["user"] == "Utilisateur introuvable."
+    assert payload["message"] == "Utilisateur introuvable."
+
+
+def test_me_requires_authorization_header(app):
+    client = app.test_client()
+
+    response = client.get("/auth/me")
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    payload = response.get_json()
+    assert payload["msg"] == "Missing Authorization Header"

--- a/tests/test_auth_refresh.py
+++ b/tests/test_auth_refresh.py
@@ -23,7 +23,7 @@ def _create_user_with_refresh_token(
         db.session.add(user)
         db.session.commit()
 
-        refresh_token = create_refresh_token(identity=user.id)
+        refresh_token = create_refresh_token(identity=str(user.id))
 
         now = datetime.now(timezone.utc)
         expires_at = now + expires_delta
@@ -54,16 +54,28 @@ def test_refresh_success(app):
     assert payload["data"]["user"]["email"] == "refresh@example.com"
     assert payload["data"]["user"]["id"] is not None
     assert payload["data"]["access_token"]
+    assert payload["data"]["refresh_token"]
     assert payload["message"] == "Token renouvelé avec succès."
 
     with app.app_context():
         user = db.session.execute(
             db.select(User).filter_by(email="refresh@example.com")
         ).scalar_one()
-        assert len(user.refresh_tokens) == 1
-        stored_token = user.refresh_tokens[0]
-        assert stored_token.token == refresh_token
-        assert not stored_token.revoked
+        assert len(user.refresh_tokens) == 2
+        tokens_by_value = {token.token: token for token in user.refresh_tokens}
+        old_token = tokens_by_value[refresh_token]
+        new_refresh_token = payload["data"]["refresh_token"]
+        assert new_refresh_token in tokens_by_value
+        rotated_token = tokens_by_value[new_refresh_token]
+        assert old_token.revoked is True
+        assert rotated_token.revoked is False
+        assert rotated_token.token != refresh_token
+
+    # Ensure the newly issued refresh token is functional
+    follow_up_response = client.post(
+        "/auth/refresh", json={"refresh_token": payload["data"]["refresh_token"]}
+    )
+    assert follow_up_response.status_code == HTTPStatus.OK
 
 
 def test_refresh_missing_token(app):
@@ -88,6 +100,26 @@ def test_refresh_invalid_token(app):
     assert payload["success"] is False
     assert payload["errors"]["refresh_token"] == "Refresh token invalide ou expiré."
     assert payload["message"] == "Token de rafraîchissement invalide."
+
+
+def test_refresh_with_rotated_token_fails_for_old_value(app):
+    refresh_token = _create_user_with_refresh_token(app)
+    client = app.test_client()
+
+    first_response = client.post(
+        "/auth/refresh", json={"refresh_token": refresh_token}
+    )
+    assert first_response.status_code == HTTPStatus.OK
+
+    second_response = client.post(
+        "/auth/refresh", json={"refresh_token": refresh_token}
+    )
+
+    assert second_response.status_code == HTTPStatus.UNAUTHORIZED
+    second_payload = second_response.get_json()
+    assert second_payload["success"] is False
+    assert second_payload["errors"]["refresh_token"] == "Refresh token invalide ou expiré."
+    assert second_payload["message"] == "Token de rafraîchissement invalide."
 
 
 def test_refresh_revoked_token(app):


### PR DESCRIPTION
## Summary
- add a JWT-protected `/auth/me` endpoint for fetching the authenticated user's profile
- implement a `/auth/logout` route and rotate refresh tokens when issuing a new access token
- expand the test suite and document closed issues tied to the new functionality

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d97e5e4278833282cd3d34e2e67af7